### PR TITLE
Fix numpy deprecations

### DIFF
--- a/examples.py
+++ b/examples.py
@@ -29,7 +29,7 @@ def test_radial_reduction():
         return np.exp(-(r/sigma)**2)
 
     distribution = np.random.choice([gauss, airy])(R, 0.3)
-    sample = np.random.poisson(distribution*200+10).astype(np.float)
+    sample = np.random.poisson(distribution*200+10).astype(float)
 
     #is this an airy or gaussian function? hard to tell with all this noise!
     plt.imshow(sample, interpolation='nearest', cmap='gray')

--- a/numpy_indexed/__init__.py
+++ b/numpy_indexed/__init__.py
@@ -14,4 +14,4 @@ __email__ = "hoogendoorn.eelco@gmail.com"
 
 pkg_dir = os.path.abspath(os.path.dirname(__file__))
 
-__version__ = '0.3.5'
+__version__ = '0.3.6'

--- a/numpy_indexed/arraysetops.py
+++ b/numpy_indexed/arraysetops.py
@@ -76,11 +76,11 @@ def contains(this, that, axis=semantics.axis_default):
     left = np.searchsorted(that._keys, this._keys, sorter=that.sorter, side='left')
     right = np.searchsorted(that._keys, this._keys, sorter=that.sorter, side='right')
 
-    flags = np.zeros(that.size + 1, dtype=np.int)
+    flags = np.zeros(that.size + 1, dtype=int)
     np.add.at(flags, left, 1)
     np.add.at(flags, right, -1)
 
-    return np.cumsum(flags)[:-1].astype(np.bool)[that.rank]
+    return np.cumsum(flags)[:-1].astype(bool)[that.rank]
 
 
 def in_(this, that, axis=semantics.axis_default):

--- a/numpy_indexed/funcs.py
+++ b/numpy_indexed/funcs.py
@@ -65,7 +65,7 @@ def count_table(*keys):
     uniques  = [i.unique  for i in indices]
     inverses = [i.inverse for i in indices]
     shape    = [i.groups  for i in indices]
-    table = np.zeros(shape, np.int)
+    table = np.zeros(shape, int)
     np.add.at(table, inverses, 1)
     return tuple(uniques), table
 
@@ -120,7 +120,7 @@ class Table(object):
         return arr
 
     def count(self):
-        table = self.allocate(np.int)
+        table = self.allocate(int)
         np.add.at(table, self.get_inverses(self.indices), 1)
         return tuple(self.uniques), table
 
@@ -131,19 +131,19 @@ class Table(object):
         return tuple(self.uniques), table
 
     def mean(self, values):
-        table = self.allocate(np.float, np.nan)
+        table = self.allocate(float, np.nan)
         keys, values = group_by(self.keys).mean(values)
         table[self.get_inverses(keys)] = values
         return tuple(self.uniques), table
 
     def first(self, values):
-        table = self.allocate(np.float, np.nan)
+        table = self.allocate(float, np.nan)
         keys, values = group_by(self.keys).first(values)
         table[self.get_inverses(keys)] = values
         return tuple(self.uniques), table
 
     def last(self, values):
-        table = self.allocate(np.float, np.nan)
+        table = self.allocate(float, np.nan)
         keys, values = group_by(self.keys).last(values)
         table[self.get_inverses(keys)] = values
         return tuple(self.uniques), table

--- a/numpy_indexed/grouping.py
+++ b/numpy_indexed/grouping.py
@@ -500,11 +500,11 @@ class GroupBy(object):
         -------
         unique: ndarray, [groups]
             unique keys
-        reduced : ndarray, [groups, ...], np.bool
+        reduced : ndarray, [groups, ...], bool
             value array, reduced over groups
         """
         values = np.asarray(values)
-        if not values.dtype == np.bool:
+        if not values.dtype == bool:
             values = values != 0
         return self.unique, self.reduce(values, axis=axis) > 0
 
@@ -522,7 +522,7 @@ class GroupBy(object):
         -------
         unique: ndarray, [groups]
             unique keys
-        reduced : ndarray, [groups, ...], np.bool
+        reduced : ndarray, [groups, ...], bool
             value array, reduced over groups
         """
         values = np.asarray(values)

--- a/numpy_indexed/index.py
+++ b/numpy_indexed/index.py
@@ -48,8 +48,8 @@ class BaseIndex(object):
         self.sorted = np.sort(self._keys)
         #the slicing points of the bins to reduce over
         if self.size == 0:
-            self.flag = np.empty(0, np.bool)
-            self.slices = np.empty(0, np.int)
+            self.flag = np.empty(0, bool)
+            self.slices = np.empty(0, int)
         else:
             self.flag = self.sorted[:-1] != self.sorted[1:]
             self.slices = np.concatenate((
@@ -123,8 +123,8 @@ class Index(BaseIndex):
         #computed sorted keys
         self.sorted = self._keys[self.sorter]
         if self.size == 0:
-            self.flag = np.empty(0, np.bool)
-            self.slices = np.empty(0, np.int)
+            self.flag = np.empty(0, bool)
+            self.slices = np.empty(0, int)
         else:
             #the slicing points of the bins to reduce over
             self.flag   = self.sorted[:-1] != self.sorted[1:]
@@ -141,14 +141,14 @@ class Index(BaseIndex):
     @property
     def inverse(self):
         """return index array that maps unique values back to original space. unique[inverse]==keys"""
-        inv = np.empty(self.size, np.int)
+        inv = np.empty(self.size, int)
         inv[self.sorter] = self.sorted_group_rank_per_key
         return inv
 
     @property
     def rank(self):
         """how high in sorted list each key is. inverse permutation of sorter, such that sorted[rank]==keys"""
-        r = np.empty(self.size, np.int)
+        r = np.empty(self.size, int)
         r[self.sorter] = np.arange(self.size)
         return r
 
@@ -221,8 +221,8 @@ class LexIndex(Index):
         self.sorted = self.take(keyviews, self.sorter)
         #the slicing points of the bins to reduce over
         if self.size == 0:
-            self.flag = np.empty(0, np.bool)
-            self.slices = np.empty(0, np.int)
+            self.flag = np.empty(0, bool)
+            self.slices = np.empty(0, int)
         else:
             self.flag   = reduce(
                 np.logical_or,
@@ -264,8 +264,8 @@ class LexIndexSimple(Index):
         self.sorted = tuple(key[self.sorter] for key in self._keys)
         #the slicing points of the bins to reduce over
         if self.size == 0:
-            self.flag = np.empty(0, np.bool)
-            self.slices = np.empty(0, np.int)
+            self.flag = np.empty(0, bool)
+            self.slices = np.empty(0, int)
         else:
             self.flag   = reduce(
                 np.logical_or,

--- a/tests/test_indexed.py
+++ b/tests/test_indexed.py
@@ -121,7 +121,7 @@ def test_setops_edgecase():
     assert np.array_equal(intersection([], []), [])
 
     assert np.array_equal(difference([1], []), [1])
-    assert difference([1], []).dtype == np.int
+    assert difference([1], []).dtype == int
 
     assert np.array_equal(union([], [], []), [])
     assert np.array_equal(exclusive([], []), [])


### PR DESCRIPTION
Fixes this warning for int, bool and float types for numpy >=1.20:

```
DeprecationWarning: `np.int` is a deprecated alias for
the builtin `int`. To silence this warning, use `int` by itself.
Doing this will not modify any behavior and is safe. When
replacing `np.int`, you may wish to use e.g. `np.int64` or
`np.int32` to specify the precision. If you wish to review
your current use, check the release note link for
additional information.
```